### PR TITLE
"Sorting" result by keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(fileName, deep, jsonSpace) {
       return this.emit('end');
     }
 
-    var joinedContents = extend.apply(this, buffer);
+    var joinedContents = sort(extend.apply(this, buffer));
     var joinedPath = path.join(firstFile.base, fileName);
     var joinedFile = new File({
       cwd: firstFile.cwd,
@@ -63,5 +63,12 @@ module.exports = function(fileName, deep, jsonSpace) {
     this.emit('end');
   }
 
+  function sort(object) {
+    return Object.keys(object).sort().reduce(function (result, key) {
+      result[key] = object[key];
+      return result;
+    }, {});
+  }
+  
   return through(bufferContents, endStream);
 };


### PR DESCRIPTION
I've noticed that this could be useful, i.e. if you trying to generate some files that then would land in version control systems, like git.

If we sort object by keys, then each time when we run gulp we could expect that diff tools will show only what really have changed. Currently each time I run gulp on three files I've got different result and my git is shouting on me that I've changed whole file, when I didn't touch JSON files at all.

I know that by definition JS Objects don't have an order, but in practice V8 implementation is keeping keys in the order they were added.